### PR TITLE
add buttons on request index page

### DIFF
--- a/app/views/requests/_buttons.html.erb
+++ b/app/views/requests/_buttons.html.erb
@@ -1,0 +1,4 @@
+<div class="d-flex flex-column">
+  <%= button_to 'Accept', request_path(request), method: :patch, params:{ :status => 'accept'}, class: 'btn btn-outline-success btn-sm mb-2' %>
+  <%= button_to 'Refuse', request_path(request), method: :patch, params:{ :status => 'refuse'}, class: 'btn btn-outline-danger btn-sm' %>
+</div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -33,11 +33,12 @@
               <%= link_to request_path(request) do %>
                 <%= image_tag "planets.jpg", width:"100" %>
               <% end %>
-              <div class="ms-2">
+              <div class="ms-2 flex-grow-1">
                 <p class="text-primary"><strong><%= request.plot.name %></strong></p>
                 <p><%= request.user.first_name %></p>
                 <p class="text-secondary little">Status: <%= request.status %></p>
               </div>
+              <%= render 'buttons', request: request %>
             </div>
           <% end %>
         <% end %>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -14,7 +14,6 @@
 
   <%= link_to 'Back', requests_path %>
   <% if @plot.user == current_user %>
-    <%= button_to 'Accept', {:status => 'accept'}, method: 'patch' %>
-    <%= button_to 'Refuse', {:status => 'refuse'}, method: 'patch' %>
+    <%= render 'buttons', request: @request %>
   <% end %>
 </div>


### PR DESCRIPTION
Add 'accept' and 'refuse' buttons on request index page so you can easily accept or refuse one request.